### PR TITLE
httpfs requires us to define the content type

### DIFF
--- a/fsio.go
+++ b/fsio.go
@@ -69,6 +69,7 @@ func (fs *FileSystem) Create(
 	}
 
 	req, _ = http.NewRequest("PUT", u.String(), data)
+        req.Header.Add("Content-Type", "application/octet-stream")
 	rsp, err = fs.client.Do(req)
 	if err != nil {
 		fmt.Errorf("FileSystem.Create(%s) - bad url: %s", loc, err.Error())


### PR DESCRIPTION
HTTPfs requires the content type defined in the headers. 

